### PR TITLE
Update regular logic

### DIFF
--- a/RandomizerMod3.0/Resources/items.xml
+++ b/RandomizerMod3.0/Resources/items.xml
@@ -4841,9 +4841,9 @@
     <newShiny>true</newShiny>
     <x>68.3</x>
     <y>41.4</y>
-    <itemLogic>Mid_Basin</itemLogic>
-    <areaLogic>Mid_Basin</areaLogic>
-    <roomLogic>Abyss_04[top1] | ((Abyss_04[left1] | Abyss_04[right1] | Abyss_04[bot1]) + (CLAW | WINGS))</roomLogic>
+    <itemLogic>Mid_Basin + (DASH | CLAW | WINGS | MILDSKIPS)</itemLogic>
+    <areaLogic>Mid_Basin + (DASH | CLAW | WINGS | MILDSKIPS)</areaLogic>
+    <roomLogic>(Abyss_04[top1] + (DASH | CLAW | WINGS | MILDSKIPS)) | ((Abyss_04[left1] | Abyss_04[right1] | Abyss_04[bot1]) + (CLAW | WINGS))</roomLogic>
     <type>Trinket</type>
     <action>Map</action>
     <pool>Map</pool>

--- a/RandomizerMod3.0/Resources/macros.xml
+++ b/RandomizerMod3.0/Resources/macros.xml
@@ -24,7 +24,7 @@
   <macro name="SKIPACID">CLAW + DASH + SUPERDASH + ACIDSKIPS</macro>
   <macro name="MINIBOSS">FIREBALL | SCREAM | QUAKE | SPICYSKIPS</macro>
   <macro name="AERIALMINIBOSS">((FIREBALL | SCREAM) + (DASH | MILDSKIPS)) | SPICYSKIPS</macro>
-  <macro name="BOSS">(Vengeful_Spirit + Shade_Soul) | (Desolate_Dive + Descending_Dark) | (Howling_Wraiths + Abyss_Shriek) | (FIREBALL + QUAKE) | (SCREAM + QUAKE) | (FIREBALL + SCREAM)</macro>
+  <macro name="BOSS">((Vengeful_Spirit + Shade_Soul) | (Desolate_Dive + Descending_Dark) | (Howling_Wraiths + Abyss_Shriek) | (FIREBALL + QUAKE) | (SCREAM + QUAKE) | (FIREBALL + SCREAM)) + (DASH | MILDSKIPS)</macro>
   <macro name="ALLSTAGS">Crossroads_Stag + Greenpath_Stag + Queen's_Station_Stag + Queen's_Gardens_Stag + City_Storerooms_Stag + King's_Station_Stag + Resting_Grounds_Stag + Distant_Village_Stag + Hidden_Station_Stag</macro>
   <macro name="LIFEBLOOD">Lifeblood_Heart | Lifeblood_Core | Joni's_Blessing</macro>
 

--- a/RandomizerMod3.0/Resources/rooms.xml
+++ b/RandomizerMod3.0/Resources/rooms.xml
@@ -3919,13 +3919,13 @@
     <sceneName>Ruins1_05</sceneName>
     <doorName>right1</doorName>
     <areaName>City_of_Tears</areaName>
-    <logic>Ruins1_05</logic>
+    <logic>Ruins1_05 + (CLAW | WINGS | Ruins1_05[top1])</logic>
   </transition>
   <transition name="Ruins1_05[right2]">
     <sceneName>Ruins1_05</sceneName>
     <doorName>right2</doorName>
     <areaName>City_of_Tears</areaName>
-    <logic>Ruins1_05 + (CLAW | WINGS | Ruins1_05[top1])</logic>
+    <logic>Ruins1_05</logic>
   </transition>
   <transition name="Ruins1_05[top1]">
     <sceneName>Ruins1_05</sceneName>

--- a/RandomizerMod3.0/Resources/waypoints.xml
+++ b/RandomizerMod3.0/Resources/waypoints.xml
@@ -98,7 +98,7 @@
   </item>
   <item name="Upper_King's_Station">
     <itemLogic>(Right_City + (CLAW | WINGS | (MILDSKIPS + DASH))) | (Lower_King's_Station + (CLAW | WINGS)) | Right_Elevator | Top_Kingdom's_Edge | (King's_Station_Stag + Can_Stag + (CLAW | WINGS | SPICYSKIPS))</itemLogic>
-    <areaLogic>(Ruins2_06[left1] + (CLAW | WINGS | MILDSKIPS)) | ((CLAW | WINGS) + (Ruins2_07[top1] | Ruins2_07[right1])) | Right_Elevator | Top_Kingdom's_Edge | (King's_Station_Stag + Can_Stag + (CLAW | WINGS | SPICYSKIPS))</areaLogic>
+    <areaLogic>(Ruins2_06[left1] + (CLAW | WINGS | MILDSKIPS)) | ((CLAW | WINGS) + (Ruins2_07[top1] | Ruins2_07[right1])) | Right_Elevator | (King's_Station_Stag + Can_Stag + (CLAW | WINGS | SPICYSKIPS))</areaLogic>
   </item>
   <item name="Right_Elevator">
     <itemLogic>Lower_Resting_Grounds | Upper_King's_Station</itemLogic>


### PR DESCRIPTION
- (DASH | MILDSKIPS) added to BOSS logic
- (DASH | CLAW | WINGS | MILDSKIPS) added to Basin Map logic
- Fixed bug where Ruins1_05[right1] and Ruins1_05[right2]
were swapped in room logic
- Fixed bug where Upper_King's_Station area logic included
Top_Kingdom's_Edge